### PR TITLE
Add GemsEconomy integration

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -103,6 +103,11 @@
             <version>1.3.4</version>
         </dependency>
         <dependency>
+            <groupId>me.xanium.gemseconomy</groupId>
+            <artifactId>GemsEconomy</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>su.nightexpress.excellentshop</groupId>
             <artifactId>NMS</artifactId>
             <version>4.3.0</version>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -103,9 +103,9 @@
             <version>1.3.4</version>
         </dependency>
         <dependency>
-            <groupId>me.xanium.gemseconomy</groupId>
+            <groupId>com.github.Ghost-chu</groupId>
             <artifactId>GemsEconomy</artifactId>
-            <version>1.3</version>
+            <version>74073694a3</version>
         </dependency>
         <dependency>
             <groupId>su.nightexpress.excellentshop</groupId>

--- a/Core/src/main/java/su/nightexpress/nexshop/api/currency/MultiCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/api/currency/MultiCurrency.java
@@ -1,0 +1,7 @@
+package su.nightexpress.nexshop.api.currency;
+
+/**
+ * It's just an interface to mark the currency as "multi".
+ */
+public interface MultiCurrency {
+}

--- a/Core/src/main/java/su/nightexpress/nexshop/api/currency/SingleCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/api/currency/SingleCurrency.java
@@ -1,0 +1,7 @@
+package su.nightexpress.nexshop.api.currency;
+
+/**
+ * It's just an interface to mark the currency as "single".
+ */
+public interface SingleCurrency {
+}

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyId.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyId.java
@@ -11,11 +11,11 @@ public class CurrencyId {
     public static final String VAULT         = "vault";
     public static final String PLAYER_POINTS = "player_points";
     public static final String GAME_POINTS   = "game_points";
-    public static final String GEMSECONOMY   = "gemseconomy";
+    public static final String GEMS_ECONOMY  = "gemseconomy";
 
     @NotNull
     public static String[] values() {
-        return new String[]{EXP, VAULT, PLAYER_POINTS, GAME_POINTS, GEMSECONOMY};
+        return new String[]{EXP, VAULT, PLAYER_POINTS, GAME_POINTS, GEMS_ECONOMY};
     }
 
     @NotNull

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyId.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyId.java
@@ -2,15 +2,25 @@ package su.nightexpress.nexshop.currency;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 public class CurrencyId {
 
     public static final String EXP           = "exp";
     public static final String VAULT         = "vault";
     public static final String PLAYER_POINTS = "player_points";
     public static final String GAME_POINTS   = "game_points";
+    public static final String GEMSECONOMY   = "gemseconomy";
 
     @NotNull
     public static String[] values() {
-        return new String[]{EXP, VAULT, PLAYER_POINTS, GAME_POINTS};
+        return new String[]{EXP, VAULT, PLAYER_POINTS, GAME_POINTS, GEMSECONOMY};
     }
+
+    @NotNull
+    public static Stream<String> stream() {
+        return Arrays.stream(values());
+    }
+
 }

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
@@ -1,7 +1,5 @@
 package su.nightexpress.nexshop.currency;
 
-import me.xanium.gemseconomy.GemsEconomy;
-import me.xanium.gemseconomy.currency.Currency;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import su.nexmedia.engine.api.config.JYML;
@@ -20,12 +18,7 @@ import su.nightexpress.nexshop.currency.internal.ExpCurrency;
 import su.nightexpress.nexshop.currency.internal.ItemCurrency;
 import su.nightexpress.nexshop.hooks.HookId;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 public class CurrencyManager extends AbstractManager<ExcellentShop> {
 
@@ -79,14 +72,7 @@ public class CurrencyManager extends AbstractManager<ExcellentShop> {
                 }
                 case CurrencyId.GEMSECONOMY -> {
                     if (Hooks.hasPlugin(HookId.GEMS_ECONOMY)) {
-
-                        // GemsEconomy plugin itself has multi currency support, which means that
-                        // we need to dynamically register an ICurrency for each currency of GemsEconomy.
-                        // This also includes the dynamic creation of currency config files in ExcellentShop.
-
-                        for (Currency currency : GemsEconomy.getInstance().getCurrencyManager().getCurrencies()) {
-                            this.registerCurrency(new GemsEconomyCurrency(currency.getSingular()));
-                        }
+                        GemsEconomyCurrency.registerCurrencies();
                     }
                 }
             }

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
@@ -84,7 +84,7 @@ public class CurrencyManager extends AbstractManager<ExcellentShop> {
                         // we need to dynamically register an ICurrency for each currency of GemsEconomy.
                         // This also includes the dynamic creation of currency config files in ExcellentShop.
 
-                        for (Currency currency : GemsEconomy.inst().getCurrencyManager().getCurrencies()) {
+                        for (Currency currency : GemsEconomy.getInstance().getCurrencyManager().getCurrencies()) {
                             this.registerCurrency(new GemsEconomyCurrency(currency.getSingular()));
                         }
                     }

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/CurrencyManager.java
@@ -70,7 +70,7 @@ public class CurrencyManager extends AbstractManager<ExcellentShop> {
                         this.registerCurrency(new PlayerPointsCurrency(config));
                     }
                 }
-                case CurrencyId.GEMSECONOMY -> {
+                case CurrencyId.GEMS_ECONOMY -> {
                     if (Hooks.hasPlugin(HookId.GEMS_ECONOMY)) {
                         GemsEconomyCurrency.registerCurrencies();
                     }

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GamePointsCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GamePointsCurrency.java
@@ -6,8 +6,9 @@ import su.nightexpress.gamepoints.api.GamePointsAPI;
 import su.nightexpress.gamepoints.data.PointUser;
 import su.nightexpress.nexshop.api.currency.AbstractCurrency;
 import su.nightexpress.nexshop.api.currency.ICurrencyConfig;
+import su.nightexpress.nexshop.api.currency.SingleCurrency;
 
-public class GamePointsCurrency extends AbstractCurrency {
+public class GamePointsCurrency extends AbstractCurrency implements SingleCurrency {
 
     public GamePointsCurrency(@NotNull ICurrencyConfig config) {
         super(config);

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
@@ -31,7 +31,7 @@ public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurren
                                                        + "gemseconomy:"
                                                        + identifier.toLowerCase(Locale.ROOT)
                                                        + ".yml");
-        jyml.set("Name", "GemsEconomy : " + identifier.toUpperCase(Locale.ROOT));
+        if (!jyml.isSet("Name")) jyml.set("Name", "GemsEconomy : " + identifier.toUpperCase(Locale.ROOT));
         CurrencyConfig config = new CurrencyConfig(ShopAPI.PLUGIN, jyml);
         config.save();
         return config;

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
@@ -39,26 +39,46 @@ public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurren
 
     @Override
     public double getBalance(@NotNull Player player) {
-        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
-        return GemsEconomy.getInstance().getAccountManager().getAccount(player).getBalance(gemsCurrency);
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(this.identifier);
+        Account account = GemsEconomy.getInstance().getAccountManager().getAccount(player);
+        validateCurrency(gemsCurrency);
+        validateAccount(account, player);
+        return account.getBalance(gemsCurrency);
     }
 
     @Override
     public void give(@NotNull Player player, double amount) {
-        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(this.identifier);
         Account account = GemsEconomy.getInstance().getAccountManager().getAccount(player);
-        if (account != null) {
-            account.deposit(gemsCurrency, amount);
-        } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());
+        validateCurrency(gemsCurrency);
+        validateAccount(account, player);
+        account.deposit(gemsCurrency, amount);
     }
 
     @Override
     public void take(@NotNull Player player, double amount) {
-        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(this.identifier);
         Account account = GemsEconomy.getInstance().getAccountManager().getAccount(player);
-        if (account != null) {
-            account.withdraw(gemsCurrency, amount);
-        } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());
+        validateCurrency(gemsCurrency);
+        validateAccount(account, player);
+        account.withdraw(gemsCurrency, amount);
+    }
+
+    private <T> void validateAccount(T account, Player player) {
+        if (account == null) {
+            throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName() + ". "
+                                            + "Please report this error to the author of GemsEconomy at: "
+                                            + "https://github.com/Ghost-chu/GemsEconomy/issues");
+        }
+    }
+
+    private <T> void validateCurrency(T currency) {
+        if (currency == null) {
+            throw new IllegalStateException("Cannot find GemsEconomy currency: " + this.identifier + ". "
+                                            + "You may have deleted a currency from the GemsEconomy database? "
+                                            + "Try to run command `/excellentshop reload` to load the "
+                                            + "currencies from GemsEconomy again.");
+        }
     }
 
 }

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
@@ -26,6 +26,16 @@ public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurren
         this.identifier = identifier;
     }
 
+    public static void registerCurrencies() {
+        // GemsEconomy plugin itself has multi currency support, which means that
+        // we need to dynamically register an ICurrency for each currency in GemsEconomy database.
+        // This also includes the dynamic creation of currency config files in ExcellentShop.
+
+        for (Currency currency : GemsEconomy.getInstance().getCurrencyManager().getCurrencies()) {
+            ShopAPI.getCurrencyManager().registerCurrency(new GemsEconomyCurrency(currency.getSingular()));
+        }
+    }
+
     private static CurrencyConfig loadOrCreateConfig(String identifier) {
         JYML jyml = JYML.loadOrExtract(ShopAPI.PLUGIN, CurrencyManager.DIR_DEFAULT
                                                        + "gemseconomy:"

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
@@ -1,0 +1,64 @@
+package su.nightexpress.nexshop.currency.external;
+
+import me.xanium.gemseconomy.GemsEconomy;
+import me.xanium.gemseconomy.account.Account;
+import me.xanium.gemseconomy.currency.Currency;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import su.nexmedia.engine.api.config.JYML;
+import su.nightexpress.nexshop.ShopAPI;
+import su.nightexpress.nexshop.api.currency.AbstractCurrency;
+import su.nightexpress.nexshop.api.currency.MultiCurrency;
+import su.nightexpress.nexshop.currency.CurrencyManager;
+import su.nightexpress.nexshop.currency.config.CurrencyConfig;
+
+import java.util.Locale;
+
+/**
+ * This class should be instantiated with a currency identifier in GemsEconomy.
+ */
+public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurrency {
+
+    private final String identifier;
+
+    public GemsEconomyCurrency(@NotNull String identifier) {
+        super(loadOrCreateConfig(identifier));
+        this.identifier = identifier;
+    }
+
+    private static CurrencyConfig loadOrCreateConfig(String identifier) {
+        JYML jyml = JYML.loadOrExtract(ShopAPI.PLUGIN, CurrencyManager.DIR_DEFAULT
+                                                       + "gemseconomy:"
+                                                       + identifier.toLowerCase(Locale.ROOT)
+                                                       + ".yml");
+        jyml.set("Name", "GemsEconomy : " + identifier.toUpperCase(Locale.ROOT));
+        CurrencyConfig config = new CurrencyConfig(ShopAPI.PLUGIN, jyml);
+        config.save();
+        return config;
+    }
+
+    @Override
+    public double getBalance(@NotNull Player player) {
+        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
+        return GemsEconomy.getAPI().pullAccount(player.getUniqueId()).getBalance(gemsCurrency);
+    }
+
+    @Override
+    public void give(@NotNull Player player, double amount) {
+        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
+        Account account = GemsEconomy.getAPI().pullAccount(player.getUniqueId());
+        if (account != null) {
+            account.deposit(gemsCurrency, amount);
+        } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());
+    }
+
+    @Override
+    public void take(@NotNull Player player, double amount) {
+        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
+        Account account = GemsEconomy.getAPI().pullAccount(player.getUniqueId());
+        if (account != null) {
+            account.withdraw(gemsCurrency, amount);
+        } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());
+    }
+
+}

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/GemsEconomyCurrency.java
@@ -39,14 +39,14 @@ public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurren
 
     @Override
     public double getBalance(@NotNull Player player) {
-        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
-        return GemsEconomy.getAPI().pullAccount(player.getUniqueId()).getBalance(gemsCurrency);
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
+        return GemsEconomy.getInstance().getAccountManager().getAccount(player).getBalance(gemsCurrency);
     }
 
     @Override
     public void give(@NotNull Player player, double amount) {
-        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
-        Account account = GemsEconomy.getAPI().pullAccount(player.getUniqueId());
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
+        Account account = GemsEconomy.getInstance().getAccountManager().getAccount(player);
         if (account != null) {
             account.deposit(gemsCurrency, amount);
         } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());
@@ -54,8 +54,8 @@ public class GemsEconomyCurrency extends AbstractCurrency implements MultiCurren
 
     @Override
     public void take(@NotNull Player player, double amount) {
-        Currency gemsCurrency = GemsEconomy.inst().getCurrencyManager().getCurrency(identifier);
-        Account account = GemsEconomy.getAPI().pullAccount(player.getUniqueId());
+        Currency gemsCurrency = GemsEconomy.getInstance().getCurrencyManager().getCurrency(identifier);
+        Account account = GemsEconomy.getInstance().getAccountManager().getAccount(player);
         if (account != null) {
             account.withdraw(gemsCurrency, amount);
         } else throw new IllegalStateException("Cannot find GemsEconomy account for player: " + player.getName());

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/PlayerPointsCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/PlayerPointsCurrency.java
@@ -7,9 +7,10 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.nexshop.api.currency.AbstractCurrency;
 import su.nightexpress.nexshop.api.currency.ICurrencyConfig;
+import su.nightexpress.nexshop.api.currency.SingleCurrency;
 import su.nightexpress.nexshop.hooks.HookId;
 
-public class PlayerPointsCurrency extends AbstractCurrency {
+public class PlayerPointsCurrency extends AbstractCurrency implements SingleCurrency {
 
     private final PlayerPointsAPI api;
 

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/external/VaultEcoCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/external/VaultEcoCurrency.java
@@ -5,8 +5,9 @@ import org.jetbrains.annotations.NotNull;
 import su.nexmedia.engine.hooks.external.VaultHook;
 import su.nightexpress.nexshop.api.currency.AbstractCurrency;
 import su.nightexpress.nexshop.api.currency.ICurrencyConfig;
+import su.nightexpress.nexshop.api.currency.SingleCurrency;
 
-public class VaultEcoCurrency extends AbstractCurrency {
+public class VaultEcoCurrency extends AbstractCurrency implements SingleCurrency {
 
     public VaultEcoCurrency(@NotNull ICurrencyConfig config) {
         super(config);

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/internal/ExpCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/internal/ExpCurrency.java
@@ -4,8 +4,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.nexshop.api.currency.AbstractCurrency;
 import su.nightexpress.nexshop.api.currency.ICurrencyConfig;
+import su.nightexpress.nexshop.api.currency.SingleCurrency;
 
-public class ExpCurrency extends AbstractCurrency {
+public class ExpCurrency extends AbstractCurrency implements SingleCurrency {
 
     public ExpCurrency(@NotNull ICurrencyConfig config) {
         super(config);

--- a/Core/src/main/java/su/nightexpress/nexshop/currency/internal/ItemCurrency.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/currency/internal/ItemCurrency.java
@@ -5,9 +5,10 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import su.nexmedia.engine.utils.PlayerUtil;
 import su.nightexpress.nexshop.api.currency.AbstractCurrency;
+import su.nightexpress.nexshop.api.currency.MultiCurrency;
 import su.nightexpress.nexshop.currency.config.CurrencyItemConfig;
 
-public class ItemCurrency extends AbstractCurrency {
+public class ItemCurrency extends AbstractCurrency implements MultiCurrency {
 
     public ItemCurrency(@NotNull CurrencyItemConfig config) {
         super(config);

--- a/Core/src/main/java/su/nightexpress/nexshop/hooks/HookId.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/hooks/HookId.java
@@ -8,6 +8,6 @@ public class HookId {
     public static final String GAME_POINTS      = "GamePoints";
     public static final String GRIEF_PREVENTION = "GriefPrevention";
     public static final String BROKER           = "Broker";
-
-    public static final String AUCTION_HOUSE = "AuctionHouse";
+    public static final String AUCTION_HOUSE    = "AuctionHouse";
+    public static final String GEMS_ECONOMY     = "GemsEconomy";
 }

--- a/Core/src/main/resources/currency/custom_item/custom_gold.yml
+++ b/Core/src/main/resources/currency/custom_item/custom_gold.yml
@@ -1,0 +1,11 @@
+Enabled: true
+Name: 'Gold'
+Format: 'x%price% %currency_name%'
+Number_Format: '#,##0'
+Item:
+  Material: GOLD_INGOT
+  Name: '&e&lGOLD INGOT'
+  Enchants:
+    fortune: 5
+  Item_Flags:
+    - HIDE_ENCHANTS


### PR DESCRIPTION
Add GemsEconomy integration! Spigot link: https://www.spigotmc.org/resources/gemseconomy-remake-unofficial-fork-1-19-ready.95658/

GemsEconomy is a bit of special case since it has multi currencies on its own. I want to keep the API of ExcellentShop intact while adding the integrations with GemsEco. So I let ExcelletShop automatically create a `ICurrency` instance for each currency in the GemsEco database. From the users' side, ExcellentShop will automatically genearate GemsEco currency config files for each currency of GemsEco in `/currency/default` if the server has GemsEco installed. This allows the users to customise the display format, etc. of  currencies of GemsEco. The config name is defined as following:

- `gemseconomy:c.yml`
- `gemseconomy:r.yml`
- `...`

where

- each config file corresponds to a currency in GemsEco
- `c` and `r` are the singular symbol of currrencies in the GemsEco database.