### PR TITLE
Add more auction placeholders to PlaceholderAPI hook

### DIFF
--- a/Core/src/main/java/su/nightexpress/nexshop/hook/PlaceholderHook.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/hook/PlaceholderHook.java
@@ -3,8 +3,12 @@ package su.nightexpress.nexshop.hook;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+
+import su.nightexpress.economybridge.EconomyBridge;
+import su.nightexpress.economybridge.api.Currency;
 import su.nightexpress.nexshop.ShopPlugin;
 import su.nightexpress.nexshop.auction.AuctionManager;
+import su.nightexpress.nexshop.auction.listing.CompletedListing;
 import su.nightexpress.nexshop.shop.chest.ChestShopModule;
 import su.nightexpress.nexshop.shop.chest.ChestUtils;
 import su.nightexpress.nexshop.shop.virtual.VirtualShopModule;
@@ -61,18 +65,76 @@ public class PlaceholderHook {
 
         @Override
         public String onPlaceholderRequest(Player player, @NotNull String params) {
-            if (player == null) return null;
-
             if (params.startsWith("auction_")) {
                 AuctionManager module = this.plugin.getAuction();
                 if (module == null) return null;
 
                 String subParams = params.substring("auction_".length());
 
+                if (subParams.equalsIgnoreCase("all_active_listings")) {
+                    return NumberUtil.format(module.getListings().getActive().size());
+                }
+                if (subParams.equalsIgnoreCase("all_completed_listings")) {
+                    return NumberUtil.format(module.getListings().getCompleted().size());
+                }
+
+                if (player == null) return null;
+
                 if (subParams.equalsIgnoreCase("max_listings")) {
                     return NumberUtil.format(module.getListingsMaximum(player));
                 }
+                if (subParams.equalsIgnoreCase("active_listings")) {
+                    return NumberUtil.format(module.getListings().getActive(player).size());
+                }
+                if (subParams.equalsIgnoreCase("unclaimed_listings")) {
+                    return NumberUtil.format(module.getListings().getUnclaimed(player).size());
+                }
+                if (subParams.equalsIgnoreCase("expired_listings")) {
+                    return NumberUtil.format(module.getListings().getExpired(player).size());
+                }
+                if (subParams.equalsIgnoreCase("claimed_listings")) {
+                    return NumberUtil.format(module.getListings().getClaimed(player).size());
+                }
+                if (subParams.startsWith("unclaimed_income_raw_")) {
+                    String currency = subParams.substring("unclaimed_income_raw_".length());
+                    return String.valueOf(
+                            module.getListings().getUnclaimed(player).stream()
+                                    .filter(listing -> listing.getCurrency().getInternalId().equalsIgnoreCase(currency))
+                                    .mapToDouble(CompletedListing::getPrice)
+                                    .sum()
+                    );
+                }
+                if (subParams.startsWith("unclaimed_income_")) {
+                    Currency currency = EconomyBridge.getCurrency(subParams.substring("unclaimed_income_".length()));
+                    return (currency == null) ? null : currency.format(
+                            module.getListings().getUnclaimed(player).stream()
+                                    .filter(listing -> listing.getCurrency().getInternalId().equalsIgnoreCase(currency.getInternalId()))
+                                    .mapToDouble(CompletedListing::getPrice)
+                                    .sum()
+                    );
+                }
+                if (subParams.startsWith("claimed_income_raw_")) {
+                    String currency = subParams.substring("claimed_income_raw_".length());
+                    return String.valueOf(
+                            module.getListings().getClaimed(player).stream()
+                                    .filter(listing -> listing.getCurrency().getInternalId().equalsIgnoreCase(currency))
+                                    .mapToDouble(CompletedListing::getPrice)
+                                    .sum()
+                    );
+                }
+                if (subParams.startsWith("claimed_income_")) {
+                    Currency currency = EconomyBridge.getCurrency(subParams.substring("claimed_income_".length()));
+                    return (currency == null) ? null : currency.format(
+                            module.getListings().getClaimed(player).stream()
+                                    .filter(listing -> listing.getCurrency().getInternalId().equalsIgnoreCase(currency.getInternalId()))
+                                    .mapToDouble(CompletedListing::getPrice)
+                                    .sum()
+                    );
+                }
             }
+
+            if (player == null) return null;
+
             else if (params.startsWith("chestshop_")) {
                 ChestShopModule module = this.plugin.getChestShop();
                 if (module == null) return null;


### PR DESCRIPTION
Tested these changes briefly. First time interacting with ExcellentShop / EconomyBridge APIs, so please let me know if I used correct methods.

#### GLOBAL
  1. `%excellentshop_auction_all_active_listings%` - Number of all currently active listings.
  2. `%excellentshop_auction_all_completed_listings%` - Number of all completed (sold) listings.
#### PLAYER
  1. `%excellentshop_auction_active_listings%` - Number active listings.
  2. `%excellentshop_auction_unclaimed_listings%` - Number unclaimed listings.
  3. `%excellentshop_auction_expired_listings%` - Number expired listings.
  4. `%excellentshop_auction_claimed_listings%` - Total number of completed (sold) listings.
  5. `%excellentshop_auction_unclaimed_income_raw_[CURRENCY_ID]%` - Income from all unclaimed listings for specified currency.
  6. `%excellentshop_auction_unclaimed_income_[CURRENCY_ID]%` -  Income from all unclaimed listings for specified currency. (Formatted)
  7. `%excellentshop_auction_claimed_income_raw_[CURRENCY_ID]%` - Income from all completed (and claimed) listings for specified currency.
  8. `%excellentshop_auction_claimed_income_[CURRENCY_ID]%` -  Income from all completed (and claimed) listings for specified currency. (Formatted)