### PR TITLE
Configurable join notifications for auctions

### DIFF
--- a/Core/src/main/java/su/nightexpress/nexshop/auction/config/AuctionConfig.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/auction/config/AuctionConfig.java
@@ -44,6 +44,16 @@ public class AuctionConfig {
         "https://hub.spigotmc.org/javadocs/spigot/org/bukkit/GameMode.html"
     );
 
+    public static final ConfigValue<Boolean> NOTIFY_UNCLAIMED_ON_JOIN = ConfigValue.create("Settings.Notify_Unclaimed_On_Join",
+            true,
+            "When enabled, players will receive a message about unclaimed listings when they join the server."
+    );
+
+    public static final ConfigValue<Boolean> NOTIFY_EXPIRED_ON_JOIN = ConfigValue.create("Settings.Notify_Expired_On_Join",
+            true,
+            "When enabled, players will receive a message about expired listings when they join the server."
+    );
+
     public static final ConfigValue<Boolean> LISTINGS_HIDE_ATTRIBUTES = ConfigValue.create("Settings.Listings.Hide_Attributes",
         false,
         "When enabled, will hide item attributes (damage, durability, etc.) of auction listings.");

--- a/Core/src/main/java/su/nightexpress/nexshop/auction/listener/AuctionListener.java
+++ b/Core/src/main/java/su/nightexpress/nexshop/auction/listener/AuctionListener.java
@@ -34,13 +34,13 @@ public class AuctionListener extends AbstractListener<ShopPlugin> {
             if (AuctionConfig.LISINGS_AUTO_CLAIM.get()) {
                 this.auctionManager.claimRewards(player, unclaimed);
             }
-            else {
+            else if (AuctionConfig.NOTIFY_UNCLAIMED_ON_JOIN.get()) {
                 AuctionLang.NOTIFY_UNCLAIMED_LISTINGS.getMessage()
                     .replace(Placeholders.GENERIC_AMOUNT, unclaimed.size())
                     .send(player);
             }
         }
-        if (expired > 0) {
+        if (expired > 0 && AuctionConfig.NOTIFY_EXPIRED_ON_JOIN.get()) {
             AuctionLang.NOTIFY_EXPIRED_LISTINGS.getMessage()
                 .replace(Placeholders.GENERIC_AMOUNT, expired)
                 .send(player);


### PR DESCRIPTION
This PR adds two new options to the `auction/settings.yml` file.

1. `Notify_Unclaimed_On_Join` - Whether players should be notified about unclaimed listings when they join the server.
2. `Notify_Expired_On_Join` -  Whether players should be notified about expired listings when they join the server.

Both defaults to `true` to keep current behavior. These changes are live on a server I run and I did not encounter any issues.